### PR TITLE
Update pensionMeansOfLivingEvidence-0.1.xsd

### DIFF
--- a/xsd/_common/pensionMeansOfLivingEvidence-0.1.xsd
+++ b/xsd/_common/pensionMeansOfLivingEvidence-0.1.xsd
@@ -244,10 +244,11 @@
 					</xsd:documentation>
 				</xsd:annotation>
 				<xsd:simpleType>
-                    <xsd:restriction base="xsd:integer">
-                        <xsd:pattern value="[0-9]{7}" />
-                    </xsd:restriction>
-                </xsd:simpleType>
+					<xsd:restriction base="xsd:integer">
+						<xsd:minInclusive value="0"/>
+						<xsd:maxInclusive value="9999999"/>
+					</xsd:restriction>
+				</xsd:simpleType>
 			</xsd:element>			
 		</xsd:sequence>
 	</xsd:complexType>


### PR DESCRIPTION
Avoid that the Amount MUST be 7 digits.
Hint: for RegEx to say 1 to 7 characters you need to use `{1,7}`. By using `{7}` only it means "exactly 7"